### PR TITLE
Pass extensions into to dispatch module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Optional keys :
 
 #### Examples
 
-Note : While the the examples below demonstrate providing `extensions` in configuration, it is not a
+Note : While the examples below demonstrate providing `extensions` in configuration, it is not a
 required parameter, and not all setups require extensions to be provided. Such is the case with
 `authz_id` as well.
 

--- a/src/brod_oauth.app.src
+++ b/src/brod_oauth.app.src
@@ -1,6 +1,6 @@
 {application, brod_oauth,
  [{description, "brod plugin for oauth bearer support"},
-  {vsn, "0.1.0"},
+  {vsn, "0.1.1"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
Some instances of confluent kafkfa require extensions, yet these were not being sucessfully passwed on to the dispatch module.

Additionally, this commit fixes up some diaylyzer discrepancies.