### PR TITLE
Allow client to pass additional callback data in token callback config

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17.2
-erlang 27.0.1
+elixir 1.18.4-otp-27
+erlang 27.3.4.1

--- a/examples/brod_elixir/lib/example.ex
+++ b/examples/brod_elixir/lib/example.ex
@@ -8,7 +8,9 @@ defmodule Example do
       partition: 0,
       brod_config: [
         connect_timeout: 60_000,
-        sasl: {:callback, :brod_oauth, %{token_callback: &Example.oauth_params/1}}
+        sasl:
+          {:callback, :brod_oauth,
+           %{token_callback: &Example.oauth_params/1, callback_data: %{env: :test}}}
       ],
       oauth: %{
         url: "http://localhost:8080/realms/waterpark-keycloak/protocol/openid-connect/token",
@@ -19,7 +21,8 @@ defmodule Example do
     }
   end
 
-  def oauth_params(_) do
+  def oauth_params(callback_data) do
+    :test = callback_data.env
     client_config = get_config()
     oauth_config = client_config.oauth
     extensions = Map.get(client_config, :extensions, %{})
@@ -128,7 +131,7 @@ defmodule Example do
     end
   end
 
-   def test(test_type) do
+  def test(test_type) do
     System.put_env("NIF_BIN_DIR", "_build/dev/lib/crc32cer/priv")
     Logger.configure(level: :info)
     info_log("Starting test for #{Atom.to_string(test_type)}")

--- a/src/brod_oauth.app.src
+++ b/src/brod_oauth.app.src
@@ -1,6 +1,6 @@
 {application, brod_oauth,
  [{description, "brod plugin for oauth bearer support"},
-  {vsn, "0.1.1"},
+  {vsn, "0.1.2"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/brod_oauth.erl
+++ b/src/brod_oauth.erl
@@ -15,6 +15,7 @@
     timeout := pos_integer(),
     handshake_vsn := non_neg_integer() | legacy,
     token_callback := fun(),
+    callback_data => map(),
     extensions => map(),
     authz_id => binary()
 }.
@@ -71,6 +72,7 @@ new(Host, Sock, HandshakeVsn, Mod, ClientId, Timeout, #{token_callback := OAuthC
         timeout => Timeout,
         handshake_vsn => HandshakeVsn,
         token_callback => OAuthCB,
+        callback_data => maps:get(callback_data, Cfg, #{}),
         authz_id => maps:get(authz_id, Cfg, <<"">>),
         extensions => maps:get(extensions, Cfg, #{})
     }.

--- a/src/brod_oauth_v1.erl
+++ b/src/brod_oauth_v1.erl
@@ -55,7 +55,7 @@ auth_begin(#{debug := Debug} = State) ->
 
 -spec auth_continue(State :: brod_oauth:state()) ->
     ok | {error, term()}.
-auth_continue(#{token_callback := TokenCB, debug := Debug} = State) ->
+auth_continue(#{token_callback := TokenCB, debug := Debug, callback_data := ClientCallbackData} = State) ->
     ?DBG(Debug, "Preparing to fire get_auth_data callback..."),
 
     #{
@@ -65,7 +65,7 @@ auth_continue(#{token_callback := TokenCB, debug := Debug} = State) ->
         debug := Debug
     } = State,
 
-    CallbackData = #{host => Host, client_id => ClientId, timeout => Timeout},
+    CallbackData = maps:merge(ClientCallbackData, #{host => Host, client_id => ClientId, timeout => Timeout}),
 
     ?DBG(Debug, "callback data to be passed", CallbackData),
 

--- a/test/brod_oauth_SUITE.erl
+++ b/test/brod_oauth_SUITE.erl
@@ -87,7 +87,7 @@ simple(_Config) ->
             gen_tcp,
             <<"client_id">>,
             42,
-            #{token_callback => fun (_) -> {ok, #{token => ?TOKEN}} end}
+            #{token_callback => fun (#{env := test}) -> {ok, #{token => ?TOKEN}} end, callback_data => #{env => test}}
         )
     ).
 


### PR DESCRIPTION
Right now token callback can only use secrets for one environment. We have a need to send to different Kafka env from same app env. 

By passing additional callback data, app can add oauth config to auth config which can then be used during callback execution.
 